### PR TITLE
fix: missing slash on base url

### DIFF
--- a/src/tools/billing.ts
+++ b/src/tools/billing.ts
@@ -34,7 +34,7 @@ export function registerBillingTools(server: McpServer) {
           requestBody.customerId = customerId;
         }
 
-        const response = await makeAbacatePayRequest<any>("billing/create", {
+        const response = await makeAbacatePayRequest<any>("/billing/create", {
           method: "POST",
           body: JSON.stringify(requestBody)
         });
@@ -78,7 +78,7 @@ export function registerBillingTools(server: McpServer) {
     {},
     async () => {
       try {
-        const response = await makeAbacatePayRequest<any>("billing/list", {
+        const response = await makeAbacatePayRequest<any>("/billing/list", {
           method: "GET"
         });
 

--- a/src/tools/coupon.ts
+++ b/src/tools/coupon.ts
@@ -32,7 +32,7 @@ export function registerCouponTools(server: McpServer) {
           requestBody.metadata = metadata;
         }
 
-        const response = await makeAbacatePayRequest<any>("coupon/create", {
+        const response = await makeAbacatePayRequest<any>("/coupon/create", {
           method: "POST",
           body: JSON.stringify(requestBody)
         });
@@ -80,7 +80,7 @@ export function registerCouponTools(server: McpServer) {
     {},
     async () => {
       try {
-        const response = await makeAbacatePayRequest<any>("coupon/list", {
+        const response = await makeAbacatePayRequest<any>("/coupon/list", {
           method: "GET"
         });
 

--- a/src/tools/customer.ts
+++ b/src/tools/customer.ts
@@ -14,7 +14,7 @@ export function registerCustomerTools(server: McpServer) {
     },
     async ({ name, cellphone, email, taxId }) => {
       try {
-        const response = await makeAbacatePayRequest<any>("customer/create", {
+        const response = await makeAbacatePayRequest<any>("/customer/create", {
           method: "POST",
           body: JSON.stringify({
             name,
@@ -51,7 +51,7 @@ export function registerCustomerTools(server: McpServer) {
     {},
     async () => {
       try {
-        const response = await makeAbacatePayRequest<any>("customer/list", {
+        const response = await makeAbacatePayRequest<any>("/customer/list", {
           method: "GET"
         });
 

--- a/src/tools/pix.ts
+++ b/src/tools/pix.ts
@@ -35,7 +35,7 @@ export function registerPixTools(server: McpServer) {
           requestBody.customer = customer;
         }
 
-        const response = await makeAbacatePayRequest<any>("pixQrCode/create", {
+        const response = await makeAbacatePayRequest<any>("/pixQrCode/create", {
           method: "POST",
           body: JSON.stringify(requestBody)
         });
@@ -90,7 +90,7 @@ export function registerPixTools(server: McpServer) {
           requestBody.metadata = metadata;
         }
 
-        const response = await makeAbacatePayRequest<any>(`pixQrCode/simulate-payment?id=${id}`, {
+        const response = await makeAbacatePayRequest<any>(`/pixQrCode/simulate-payment?id=${id}`, {
           method: "POST",
           body: JSON.stringify(requestBody)
         });
@@ -147,7 +147,7 @@ export function registerPixTools(server: McpServer) {
     },
     async ({ id }) => {
       try {
-        const response = await makeAbacatePayRequest<any>(`pixQrCode/check?id=${id}`, {
+        const response = await makeAbacatePayRequest<any>(`/pixQrCode/check?id=${id}`, {
           method: "GET"
         });
 


### PR DESCRIPTION
Este PR corrige um bug crítico que estava afetando todos os requests da API do Abacate Pay, manifestando-se com erros 404 como "Route GET:/v1customer/list not found". 

![image](https://github.com/user-attachments/assets/885cdac3-61b8-4e7c-b8d7-f58ff6139ae8)

O problema estava na concatenação incorreta das URLs em toda a aplicação, onde os caminhos dos endpoints estavam sendo colados diretamente na URL base sem o separador adequado, resultando em rotas malformadas que não conseguiam ser encontradas pelo sistema.

A solução implementada adiciona a barra inicial "/" em todos os caminhos dos endpoints, garantindo a construção adequada das URLs quando concatenadas com a URL base.
