### PR TITLE
feat: complete v2 coverage (refunds, subscriptions, webhooks) + tests

### DIFF
--- a/.changeset/completa-v2.md
+++ b/.changeset/completa-v2.md
@@ -1,0 +1,9 @@
+---
+"abacatepay-mcp": minor
+---
+
+Completa a cobertura da API v2 e adiciona testes.
+
+- Novas tools v2: reembolsos (`v2RefundCheckout`, `v2RefundPaymentLink`, `v2RefundTransparentPix`), ciclo de assinatura (`v2CancelSubscription`, `v2ChangeSubscriptionPlan`, `v2RecordSubscriptionUsage`) e webhooks (`v2CreateWebhook`, `v2ListWebhooks`, `v2GetWebhook`, `v2DeleteWebhook`).
+- Helpers de tool extraídos para `src/tools/shared.ts`; tools v1 passam a usar `apiKeyParam` compartilhado (sem mudança de comportamento).
+- Suíte de testes `bun:test`: unit com `fetch` mockado (no CI) + smoke gated por `ABACATE_PAY_SMOKE`.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,6 +56,16 @@ jobs:
         fi
         echo "✅ Todos os tipos estão corretos"
 
+    - name: 🧪 Testes unitários
+      run: |
+        echo "🧪 Rodando testes unitários..."
+        bun test tests/unit
+        if [ $? -ne 0 ]; then
+          echo "❌ Testes falharam!"
+          exit 1
+        fi
+        echo "✅ Testes unitários passaram"
+
     - name: 🧪 Verificação do script inspector
       run: |
         echo "🧪 Testando script inspector..."

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,7 +59,7 @@ jobs:
     - name: 🧪 Testes unitários
       run: |
         echo "🧪 Rodando testes unitários..."
-        bun test tests/unit
+        env -u ABACATE_PAY_API_KEY bun test tests/unit
         if [ $? -ne 0 ]; then
           echo "❌ Testes falharam!"
           exit 1

--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ Troque `API_KEY` pela sua chave ([Integrar](https://www.abacatepay.com) → **AP
 
 ## Ferramentas (resumo)
 
-- **v2:** clientes, cupons, produtos, checkouts, links de pagamento, Pix transparente, payouts, envio Pix, assinaturas, loja e métricas públicas. Implementação: `src/tools/v2/`.
+- **v2:** clientes, cupons, produtos, checkouts (criar/listar/obter/reembolsar), links de pagamento (criar/listar/obter/reembolsar), Pix transparente (criar/checar/simular/listar/reembolsar), payouts, envio Pix, assinaturas (checkout/listar/cancelar/trocar plano/registrar uso), webhooks (criar/listar/obter/deletar), loja e métricas públicas. Implementação: `src/tools/v2/`.
 - **v1:** clientes (`/customer/*`), cobranças (`/billing/*`), QR Pix (`/pixQrCode/*`), cupons (`/coupon/*`), saques (`/withdraw/*`). Implementação: `src/tools/*.ts` (exceto `v2/`).
 
 Nomes exatos das tools são os registrados no código; a lista completa aparece no cliente MCP ao conectar.

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -20,8 +20,10 @@ export default [
         fetch: 'readonly',
         RequestInit: 'readonly',
         HeadersInit: 'readonly',
+        URL: 'readonly',
         URLSearchParams: 'readonly',
-        Response: 'readonly'
+        Response: 'readonly',
+        AbortSignal: 'readonly'
       }
     },
     plugins: {

--- a/package.json
+++ b/package.json
@@ -10,6 +10,8 @@
     "dev": "bun --watch src/index.ts",
     "dev:http": "bun --watch src/http-server.ts",
     "inspector": "bun run scripts/inspector.js",
+    "test": "bun test tests/unit",
+    "test:smoke": "ABACATE_PAY_SMOKE=1 bun test tests/smoke",
     "lint": "eslint src/ scripts/ --ext .ts,.js",
     "lint:fix": "eslint src/ scripts/ --ext .ts,.js --fix",
     "security": "bun audit && bun run lint",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "dev:http": "bun --watch src/http-server.ts",
     "inspector": "bun run scripts/inspector.js",
     "test": "bun test tests/unit",
-    "test:smoke": "ABACATE_PAY_SMOKE=1 bun test tests/smoke",
+    "test:smoke": "ABACATE_PAY_SMOKE=1 bun test ./tests/smoke/v2-read.smoke.ts",
     "lint": "eslint src/ scripts/ --ext .ts,.js",
     "lint:fix": "eslint src/ scripts/ --ext .ts,.js --fix",
     "security": "bun audit && bun run lint",

--- a/src/oauth/crypto.ts
+++ b/src/oauth/crypto.ts
@@ -32,7 +32,9 @@ export function loadEncryptionKey(dbPath: string): Buffer {
 
   const keyPath = dbPath.replace(/\.db$/i, "") + ".key";
 
+  // eslint-disable-next-line security/detect-non-literal-fs-filename -- keyPath derived from OAUTH_DB_PATH/OAUTH_ENCRYPTION_KEY operator config, not user input
   if (existsSync(keyPath)) {
+    // eslint-disable-next-line security/detect-non-literal-fs-filename -- see above
     const raw = readFileSync(keyPath, "utf8").trim();
     const key = Buffer.from(raw, "hex");
     if (key.length !== 32) {
@@ -43,7 +45,9 @@ export function loadEncryptionKey(dbPath: string): Buffer {
 
   const key = randomBytes(32);
   const dir = dirname(keyPath);
+  // eslint-disable-next-line security/detect-non-literal-fs-filename -- dir derived from OAUTH_DB_PATH/OAUTH_ENCRYPTION_KEY operator config, not user input
   if (!existsSync(dir)) mkdirSync(dir, { recursive: true });
+  // eslint-disable-next-line security/detect-non-literal-fs-filename -- see above
   writeFileSync(keyPath, key.toString("hex"), { mode: 0o600 });
 
   console.error(`🔑 OAuth encryption key auto-generated → ${keyPath}`);

--- a/src/oauth/store.ts
+++ b/src/oauth/store.ts
@@ -11,6 +11,7 @@ import { decrypt, encrypt, loadEncryptionKey } from "./crypto.js";
 const DB_PATH = resolve(process.env.OAUTH_DB_PATH ?? "./oauth.db");
 
 const dbDir = dirname(DB_PATH);
+// eslint-disable-next-line security/detect-non-literal-fs-filename -- dbDir derived from OAUTH_DB_PATH operator config, not user input
 if (!existsSync(dbDir)) mkdirSync(dbDir, { recursive: true });
 
 const encKey = loadEncryptionKey(DB_PATH);

--- a/src/tools/billing.ts
+++ b/src/tools/billing.ts
@@ -1,6 +1,7 @@
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { z } from "zod";
 import { makeAbacatePayRequest } from "../http/api.js";
+import { apiKeyParam } from "./shared.js";
 
 const customerPayload = z
   .object({
@@ -26,12 +27,7 @@ export function registerBillingTools(server: McpServer) {
     "createBilling",
     "Cria uma nova cobrança no Abacate Pay (API v1 — requer chave v1).",
     {
-      apiKey: z
-        .string()
-        .optional()
-        .describe(
-          "Override opcional. Em HTTP multi-tenant prefira Authorization ou X-API-Key; em stdio use ABACATE_PAY_API_KEY."
-        ),
+      apiKey: apiKeyParam("v1"),
       frequency: z
         .enum(["ONE_TIME", "MULTIPLE_PAYMENTS"])
         .default("ONE_TIME")
@@ -131,12 +127,7 @@ export function registerBillingTools(server: McpServer) {
     "listBillings",
     "Lista todas as cobranças criadas no Abacate Pay (API v1 — requer chave v1).",
     {
-      apiKey: z
-        .string()
-        .optional()
-        .describe(
-          "Override opcional. Em HTTP multi-tenant prefira Authorization ou X-API-Key; em stdio use ABACATE_PAY_API_KEY."
-        ),
+      apiKey: apiKeyParam("v1"),
     },
     async (params, extra) => {
       const { apiKey } = params as any;

--- a/src/tools/coupon.ts
+++ b/src/tools/coupon.ts
@@ -1,18 +1,14 @@
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { z } from "zod";
 import { makeAbacatePayRequest } from "../http/api.js";
+import { apiKeyParam } from "./shared.js";
 
 export function registerCouponTools(server: McpServer) {
   server.tool(
     "createCoupon",
     "Cria um novo cupom de desconto (API v1 — requer chave v1).",
     {
-      apiKey: z
-        .string()
-        .optional()
-        .describe(
-          "Override opcional. Em HTTP multi-tenant prefira Authorization ou X-API-Key; em stdio use ABACATE_PAY_API_KEY."
-        ),
+      apiKey: apiKeyParam("v1"),
       code: z.string().describe("Código único do cupom (ex: DESCONTO20)"),
       discountKind: z
         .enum(["PERCENTAGE", "FIXED"])
@@ -87,12 +83,7 @@ export function registerCouponTools(server: McpServer) {
     "listCoupons",
     "Lista todos os cupons de desconto criados no Abacate Pay (API v1 — requer chave v1).",
     {
-      apiKey: z
-        .string()
-        .optional()
-        .describe(
-          "Override opcional. Em HTTP multi-tenant prefira Authorization ou X-API-Key; em stdio use ABACATE_PAY_API_KEY."
-        ),
+      apiKey: apiKeyParam("v1"),
     },
     async (params, extra) => {
       const { apiKey } = params as any;

--- a/src/tools/customer.ts
+++ b/src/tools/customer.ts
@@ -1,18 +1,14 @@
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { z } from "zod";
 import { makeAbacatePayRequest } from "../http/api.js";
+import { apiKeyParam } from "./shared.js";
 
 export function registerCustomerTools(server: McpServer) {
   server.tool(
     "createCustomer",
     "Cria um novo cliente no Abacate Pay (API v1 — requer chave v1).",
     {
-      apiKey: z
-        .string()
-        .optional()
-        .describe(
-          "Override opcional. Em HTTP multi-tenant prefira Authorization ou X-API-Key; em stdio use ABACATE_PAY_API_KEY."
-        ),
+      apiKey: apiKeyParam("v1"),
       name: z.string().describe("Nome completo do cliente"),
       cellphone: z.string().describe("Celular do cliente (ex: (11) 4002-8922)"),
       email: z.string().email().describe("E-mail do cliente"),
@@ -60,12 +56,7 @@ export function registerCustomerTools(server: McpServer) {
     "listCustomers",
     "Lista todos os clientes cadastrados no Abacate Pay (API v1 — requer chave v1).",
     {
-      apiKey: z
-        .string()
-        .optional()
-        .describe(
-          "Override opcional. Em HTTP multi-tenant prefira Authorization ou X-API-Key; em stdio use ABACATE_PAY_API_KEY."
-        ),
+      apiKey: apiKeyParam("v1"),
     },
     async (params, extra) => {
       const { apiKey } = params as any;

--- a/src/tools/pix.ts
+++ b/src/tools/pix.ts
@@ -1,18 +1,14 @@
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { z } from "zod";
 import { makeAbacatePayRequest } from "../http/api.js";
+import { apiKeyParam } from "./shared.js";
 
 export function registerPixTools(server: McpServer) {
   server.tool(
     "createPixQrCode",
     "Cria um QR Code PIX para pagamento direto (API v1 — requer chave v1).",
     {
-      apiKey: z
-        .string()
-        .optional()
-        .describe(
-          "Override opcional. Em HTTP multi-tenant prefira Authorization ou X-API-Key; em stdio use ABACATE_PAY_API_KEY."
-        ),
+      apiKey: apiKeyParam("v1"),
       amount: z.number().describe("Valor da cobrança em centavos"),
       expiresIn: z.number().optional().describe("Tempo de expiração em segundos (opcional)"),
       description: z
@@ -99,12 +95,7 @@ export function registerPixTools(server: McpServer) {
     "simulatePixPayment",
     "Simula o pagamento de um QR Code PIX (apenas em modo desenvolvimento; API v1).",
     {
-      apiKey: z
-        .string()
-        .optional()
-        .describe(
-          "Override opcional. Em HTTP multi-tenant prefira Authorization ou X-API-Key; em stdio use ABACATE_PAY_API_KEY."
-        ),
+      apiKey: apiKeyParam("v1"),
       id: z.string().describe("ID do QR Code PIX para simular o pagamento"),
       metadata: z.record(z.unknown()).optional().describe("Metadados opcionais para a requisição"),
     },
@@ -175,12 +166,7 @@ export function registerPixTools(server: McpServer) {
     "checkPixStatus",
     "Verifica o status de um QR Code PIX (API v1 — requer chave v1).",
     {
-      apiKey: z
-        .string()
-        .optional()
-        .describe(
-          "Override opcional. Em HTTP multi-tenant prefira Authorization ou X-API-Key; em stdio use ABACATE_PAY_API_KEY."
-        ),
+      apiKey: apiKeyParam("v1"),
       id: z.string().describe("ID do QR Code PIX para verificar o status"),
     },
     async (params, extra) => {

--- a/src/tools/shared.ts
+++ b/src/tools/shared.ts
@@ -1,0 +1,54 @@
+import { z } from "zod";
+
+export type ApiVersion = "v1" | "v2";
+
+const API_KEY_DESC_V1 =
+  "Override opcional. Em HTTP multi-tenant prefira Authorization ou X-API-Key; em stdio use ABACATE_PAY_API_KEY.";
+const API_KEY_DESC_V2 =
+  "Override opcional (chave v2). Em HTTP multi-tenant prefira Authorization ou X-API-Key; em stdio use uma chave v2 em ABACATE_PAY_API_KEY.";
+
+export function apiKeyParam(version: ApiVersion) {
+  const desc = version === "v2" ? API_KEY_DESC_V2 : API_KEY_DESC_V1;
+  return z.string().optional().describe(desc);
+}
+
+export type Pagination = {
+  hasMore?: boolean;
+  next?: string | null;
+  before?: string | null;
+};
+
+export function paginationHint(pagination: Pagination | undefined): string {
+  if (!pagination) return "";
+  const parts: string[] = [];
+  if (pagination.hasMore && pagination.next) {
+    parts.push(`Próxima página: use after="${pagination.next}".`);
+  }
+  if (pagination.before) {
+    parts.push(`Anterior: before="${pagination.before}".`);
+  }
+  return parts.length ? `\n\n📄 **Paginação:** ${parts.join(" ")}` : "";
+}
+
+export function buildQuery(
+  params: Record<string, string | number | undefined | null>
+): string {
+  const q = new URLSearchParams();
+  for (const [k, v] of Object.entries(params)) {
+    if (v === undefined || v === null || v === "") continue;
+    q.set(k, String(v));
+  }
+  const s = q.toString();
+  return s ? `?${s}` : "";
+}
+
+export function toolError(e: unknown): { content: Array<{ type: "text"; text: string }> } {
+  return {
+    content: [
+      {
+        type: "text",
+        text: e instanceof Error ? e.message : "Erro desconhecido",
+      },
+    ],
+  };
+}

--- a/src/tools/shared.ts
+++ b/src/tools/shared.ts
@@ -7,6 +7,7 @@ const API_KEY_DESC_V1 =
 const API_KEY_DESC_V2 =
   "Override opcional (chave v2). Em HTTP multi-tenant prefira Authorization ou X-API-Key; em stdio use uma chave v2 em ABACATE_PAY_API_KEY.";
 
+/** Schema zod opcional do parâmetro `apiKey`, com a descrição correta por versão. */
 export function apiKeyParam(version: ApiVersion) {
   const desc = version === "v2" ? API_KEY_DESC_V2 : API_KEY_DESC_V1;
   return z.string().optional().describe(desc);

--- a/src/tools/v2/checkouts.ts
+++ b/src/tools/v2/checkouts.ts
@@ -127,4 +127,34 @@ export function registerV2CheckoutTools(server: McpServer) {
       }
     }
   );
+
+  server.tool(
+    "v2RefundCheckout",
+    "Reembolsa integralmente um checkout pago (API v2 — chave v2). Reembolso parcial não é suportado.",
+    {
+      apiKey: v2ApiKey,
+      id: z.string().describe("ID público do recurso (char_/pix_char_/card_/bill_)."),
+      reason: z.string().max(500).optional().describe("Motivo do reembolso."),
+    },
+    async (params, extra) => {
+      const p = params as any;
+      try {
+        const body: Record<string, unknown> = { id: p.id };
+        if (p.reason) body.reason = p.reason;
+        const res = await makeAbacatePayRequest<any>({
+          version: "v2",
+          path: "/checkouts/refund",
+          apiKey: p.apiKey,
+          sessionId: extra.sessionId,
+          method: "POST",
+          body: JSON.stringify(body),
+        });
+        return {
+          content: [{ type: "text", text: `Checkout reembolsado\nrefund: ${res.data?.refundPublicId}` }],
+        };
+      } catch (e) {
+        return toolError(e);
+      }
+    }
+  );
 }

--- a/src/tools/v2/helpers.ts
+++ b/src/tools/v2/helpers.ts
@@ -1,47 +1,7 @@
-import { z } from "zod";
+import { apiKeyParam } from "../shared.js";
 
-export const v2ApiKey = z
-  .string()
-  .optional()
-  .describe(
-    "Override opcional (chave v2). Em HTTP multi-tenant prefira Authorization ou X-API-Key; em stdio use uma chave v2 em ABACATE_PAY_API_KEY."
-  );
+export { buildQuery, paginationHint, toolError } from "../shared.js";
+export type { Pagination as V2Pagination } from "../shared.js";
 
-export type V2Pagination = {
-  hasMore?: boolean;
-  next?: string | null;
-  before?: string | null;
-};
-
-export function paginationHint(pagination: V2Pagination | undefined): string {
-  if (!pagination) return "";
-  const parts: string[] = [];
-  if (pagination.hasMore && pagination.next) {
-    parts.push(`Próxima página: use after="${pagination.next}".`);
-  }
-  if (pagination.before) {
-    parts.push(`Anterior: before="${pagination.before}".`);
-  }
-  return parts.length ? `\n\n📄 **Paginação:** ${parts.join(" ")}` : "";
-}
-
-export function buildQuery(params: Record<string, string | number | undefined | null>): string {
-  const q = new URLSearchParams();
-  for (const [k, v] of Object.entries(params)) {
-    if (v === undefined || v === null || v === "") continue;
-    q.set(k, String(v));
-  }
-  const s = q.toString();
-  return s ? `?${s}` : "";
-}
-
-export function toolError(e: unknown): { content: Array<{ type: "text"; text: string }> } {
-  return {
-    content: [
-      {
-        type: "text",
-        text: e instanceof Error ? e.message : "Erro desconhecido",
-      },
-    ],
-  };
-}
+/** Chave v2 (override opcional). */
+export const v2ApiKey = apiKeyParam("v2");

--- a/src/tools/v2/index.ts
+++ b/src/tools/v2/index.ts
@@ -9,6 +9,7 @@ import { registerV2ProductTools } from "./products.js";
 import { registerV2StoreTools } from "./store.js";
 import { registerV2SubscriptionTools } from "./subscriptions.js";
 import { registerV2TransparentTools } from "./transparents.js";
+import { registerV2WebhookTools } from "./webhooks.js";
 
 /** Registra ferramentas que chamam apenas https://api.abacatepay.com/v2 (chave API v2). */
 export function registerV2Tools(server: McpServer) {
@@ -22,4 +23,5 @@ export function registerV2Tools(server: McpServer) {
   registerV2PixSendTools(server);
   registerV2SubscriptionTools(server);
   registerV2StoreTools(server);
+  registerV2WebhookTools(server);
 }

--- a/src/tools/v2/payment-links.ts
+++ b/src/tools/v2/payment-links.ts
@@ -120,4 +120,34 @@ export function registerV2PaymentLinkTools(server: McpServer) {
       }
     }
   );
+
+  server.tool(
+    "v2RefundPaymentLink",
+    "Reembolsa integralmente um pagamento de link (API v2 — chave v2).",
+    {
+      apiKey: v2ApiKey,
+      id: z.string().describe("ID público do recurso (char_/pix_char_/card_/bill_)."),
+      reason: z.string().max(500).optional().describe("Motivo do reembolso."),
+    },
+    async (params, extra) => {
+      const p = params as any;
+      try {
+        const body: Record<string, unknown> = { id: p.id };
+        if (p.reason) body.reason = p.reason;
+        const res = await makeAbacatePayRequest<any>({
+          version: "v2",
+          path: "/payment-links/refund",
+          apiKey: p.apiKey,
+          sessionId: extra.sessionId,
+          method: "POST",
+          body: JSON.stringify(body),
+        });
+        return {
+          content: [{ type: "text", text: `Link reembolsado\nrefund: ${res.data?.refundPublicId}` }],
+        };
+      } catch (e) {
+        return toolError(e);
+      }
+    }
+  );
 }

--- a/src/tools/v2/subscriptions.ts
+++ b/src/tools/v2/subscriptions.ts
@@ -96,4 +96,87 @@ export function registerV2SubscriptionTools(server: McpServer) {
       }
     }
   );
+
+  server.tool(
+    "v2CancelSubscription",
+    "Cancela imediatamente uma assinatura ativa (API v2 — chave v2). Irreversível.",
+    {
+      apiKey: v2ApiKey,
+      id: z.string().describe("ID da assinatura (subs_...)."),
+    },
+    async (params, extra) => {
+      const p = params as any;
+      try {
+        const res = await makeAbacatePayRequest<any>({
+          version: "v2",
+          path: "/subscriptions/cancel",
+          apiKey: p.apiKey,
+          sessionId: extra.sessionId,
+          method: "POST",
+          body: JSON.stringify({ id: p.id }),
+        });
+        const d = res.data;
+        return {
+          content: [{ type: "text", text: `Assinatura cancelada: ${d?.id} — ${d?.status}` }],
+        };
+      } catch (e) {
+        return toolError(e);
+      }
+    }
+  );
+
+  server.tool(
+    "v2ChangeSubscriptionPlan",
+    "Agenda alteração do produto principal de uma assinatura para o próximo ciclo (API v2 — chave v2). Produto deve ter ciclo de cobrança.",
+    {
+      apiKey: v2ApiKey,
+      id: z.string().describe("ID da assinatura (subs_...)."),
+      productId: z.string().describe("ID do novo produto (com ciclo)."),
+      quantity: z.number().int().min(1).describe("Quantidade do novo produto."),
+    },
+    async (params, extra) => {
+      const p = params as any;
+      try {
+        const res = await makeAbacatePayRequest<any>({
+          version: "v2",
+          path: "/subscriptions/change-plan",
+          apiKey: p.apiKey,
+          sessionId: extra.sessionId,
+          method: "POST",
+          body: JSON.stringify({ id: p.id, productId: p.productId, quantity: p.quantity }),
+        });
+        return { content: [{ type: "text", text: `Plano alterado (agendado):\n${JSON.stringify(res.data, null, 2)}` }] };
+      } catch (e) {
+        return toolError(e);
+      }
+    }
+  );
+
+  server.tool(
+    "v2RecordSubscriptionUsage",
+    "Registra uso (pay-as-you-go) numa assinatura ativa (API v2 — chave v2). Produto NÃO deve ter ciclo de cobrança.",
+    {
+      apiKey: v2ApiKey,
+      id: z.string().describe("ID da assinatura (subs_...)."),
+      productId: z.string().describe("ID do produto de uso (sem ciclo)."),
+      units: z.number().int().min(1).describe("Unidades a registrar."),
+      action: z.enum(["add", "subtract"]).describe("add: acrescenta; subtract: estorna."),
+    },
+    async (params, extra) => {
+      const p = params as any;
+      try {
+        const res = await makeAbacatePayRequest<any>({
+          version: "v2",
+          path: "/subscriptions/record-usage",
+          apiKey: p.apiKey,
+          sessionId: extra.sessionId,
+          method: "POST",
+          body: JSON.stringify({ id: p.id, productId: p.productId, units: p.units, action: p.action }),
+        });
+        return { content: [{ type: "text", text: `Uso registrado:\n${JSON.stringify(res.data, null, 2)}` }] };
+      } catch (e) {
+        return toolError(e);
+      }
+    }
+  );
 }

--- a/src/tools/v2/transparents.ts
+++ b/src/tools/v2/transparents.ts
@@ -154,4 +154,34 @@ export function registerV2TransparentTools(server: McpServer) {
       }
     }
   );
+
+  server.tool(
+    "v2RefundTransparentPix",
+    "Reembolsa integralmente um PIX transparente pago (API v2 — chave v2).",
+    {
+      apiKey: v2ApiKey,
+      id: z.string().describe("ID público do recurso (char_/pix_char_/card_/bill_)."),
+      reason: z.string().max(500).optional().describe("Motivo do reembolso."),
+    },
+    async (params, extra) => {
+      const p = params as any;
+      try {
+        const body: Record<string, unknown> = { id: p.id };
+        if (p.reason) body.reason = p.reason;
+        const res = await makeAbacatePayRequest<any>({
+          version: "v2",
+          path: "/transparents/refund",
+          apiKey: p.apiKey,
+          sessionId: extra.sessionId,
+          method: "POST",
+          body: JSON.stringify(body),
+        });
+        return {
+          content: [{ type: "text", text: `PIX reembolsado\nrefund: ${res.data?.refundPublicId}` }],
+        };
+      } catch (e) {
+        return toolError(e);
+      }
+    }
+  );
 }

--- a/src/tools/v2/webhooks.ts
+++ b/src/tools/v2/webhooks.ts
@@ -1,0 +1,147 @@
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { z } from "zod";
+import { makeAbacatePayRequest } from "../../http/api.js";
+import { buildQuery, paginationHint, toolError, v2ApiKey } from "./helpers.js";
+
+const webhookEvent = z.enum([
+  "checkout.completed",
+  "checkout.refunded",
+  "checkout.disputed",
+  "checkout.lost",
+  "transparent.completed",
+  "transparent.refunded",
+  "transparent.disputed",
+  "transparent.lost",
+  "subscription.completed",
+  "subscription.trial_started",
+  "subscription.cancelled",
+  "subscription.renewed",
+  "payout.completed",
+  "payout.failed",
+  "transfer.completed",
+  "transfer.failed",
+]);
+
+export function registerV2WebhookTools(server: McpServer) {
+  server.tool(
+    "v2CreateWebhook",
+    "Cria um webhook para receber eventos da loja (API v2 — chave v2). endpoint deve ser HTTPS público.",
+    {
+      apiKey: v2ApiKey,
+      name: z.string().describe("Nome identificador do webhook."),
+      endpoint: z.string().url().describe("URL HTTPS que recebe as notificações."),
+      secret: z.string().describe("Segredo usado para autenticar o webhook."),
+      events: z.array(webhookEvent).min(1).describe("Eventos a assinar."),
+    },
+    async (params, extra) => {
+      const p = params as any;
+      try {
+        const res = await makeAbacatePayRequest<any>({
+          version: "v2",
+          path: "/webhooks/create",
+          apiKey: p.apiKey,
+          sessionId: extra.sessionId,
+          method: "POST",
+          body: JSON.stringify({
+            name: p.name,
+            endpoint: p.endpoint,
+            secret: p.secret,
+            events: p.events,
+          }),
+        });
+        const d = res.data;
+        return {
+          content: [{ type: "text", text: `Webhook criado: ${d?.id}\n${d?.name} → ${d?.endpoint}` }],
+        };
+      } catch (e) {
+        return toolError(e);
+      }
+    }
+  );
+
+  server.tool(
+    "v2ListWebhooks",
+    "Lista webhooks da loja com paginação (API v2 — chave v2).",
+    {
+      apiKey: v2ApiKey,
+      search: z.string().optional(),
+      after: z.string().optional(),
+      before: z.string().optional(),
+      limit: z.number().min(1).max(100).optional(),
+      id: z.string().optional(),
+    },
+    async (params, extra) => {
+      const p = params as any;
+      try {
+        const res = await makeAbacatePayRequest<any>({
+          version: "v2",
+          path: `/webhooks/list${buildQuery({
+            limit: p.limit,
+            search: p.search,
+            after: p.after,
+            before: p.before,
+            id: p.id,
+          })}`,
+          apiKey: p.apiKey,
+          sessionId: extra.sessionId,
+          method: "GET",
+        });
+        const rows =
+          res.data?.map((w: any, i: number) => `${i + 1}. ${w.id} — ${w.name} — ${w.endpoint}`).join("\n") ||
+          "Nenhum webhook.";
+        return { content: [{ type: "text", text: `${rows}${paginationHint(res.pagination)}` }] };
+      } catch (e) {
+        return toolError(e);
+      }
+    }
+  );
+
+  server.tool(
+    "v2GetWebhook",
+    "Busca um webhook por id (API v2 — chave v2).",
+    {
+      apiKey: v2ApiKey,
+      id: z.string().describe("ID do webhook (webh_...)."),
+    },
+    async (params, extra) => {
+      const p = params as any;
+      try {
+        const res = await makeAbacatePayRequest<any>({
+          version: "v2",
+          path: `/webhooks/get${buildQuery({ id: p.id })}`,
+          apiKey: p.apiKey,
+          sessionId: extra.sessionId,
+          method: "GET",
+        });
+        return { content: [{ type: "text", text: JSON.stringify(res.data, null, 2) }] };
+      } catch (e) {
+        return toolError(e);
+      }
+    }
+  );
+
+  server.tool(
+    "v2DeleteWebhook",
+    "Remove um webhook da loja (API v2 — chave v2). Irreversível.",
+    {
+      apiKey: v2ApiKey,
+      id: z.string().describe("ID do webhook (webh_...)."),
+    },
+    async (params, extra) => {
+      const p = params as any;
+      try {
+        const res = await makeAbacatePayRequest<any>({
+          version: "v2",
+          path: "/webhooks/delete",
+          apiKey: p.apiKey,
+          sessionId: extra.sessionId,
+          method: "POST",
+          body: JSON.stringify({ id: p.id }),
+        });
+        return { content: [{ type: "text", text: `Webhook removido: ${res.data?.id ?? p.id}` }] };
+      } catch (e) {
+        return toolError(e);
+      }
+    }
+  );
+}

--- a/src/tools/withdraw.ts
+++ b/src/tools/withdraw.ts
@@ -1,6 +1,7 @@
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { z } from "zod";
 import { makeAbacatePayRequest } from "../http/api.js";
+import { apiKeyParam } from "./shared.js";
 
 const pixKeySchema = z
   .object({
@@ -14,12 +15,7 @@ export function registerWithdrawTools(server: McpServer) {
     "createWithdraw",
     "Cria um saque para transferir valores da conta para uma chave PIX (API v1 — requer chave v1).",
     {
-      apiKey: z
-        .string()
-        .optional()
-        .describe(
-          "Override opcional. Em HTTP multi-tenant prefira Authorization ou X-API-Key; em stdio use ABACATE_PAY_API_KEY."
-        ),
+      apiKey: apiKeyParam("v1"),
       description: z.string().optional().describe("Descrição opcional do saque"),
       externalId: z.string().describe("ID externo único do saque no seu sistema"),
       method: z.literal("PIX").describe("Método de saque (apenas PIX na API v1)"),
@@ -89,12 +85,7 @@ export function registerWithdrawTools(server: McpServer) {
     "listWithdraw",
     "Lista todos os saques criados (API v1 — requer chave v1).",
     {
-      apiKey: z
-        .string()
-        .optional()
-        .describe(
-          "Override opcional. Em HTTP multi-tenant prefira Authorization ou X-API-Key; em stdio use ABACATE_PAY_API_KEY."
-        ),
+      apiKey: apiKeyParam("v1"),
     },
     async (params, extra) => {
       const { apiKey } = params as any;
@@ -143,12 +134,7 @@ export function registerWithdrawTools(server: McpServer) {
     "getWithdraw",
     "Busca um saque pelo externalId (API v1 — requer chave v1).",
     {
-      apiKey: z
-        .string()
-        .optional()
-        .describe(
-          "Override opcional. Em HTTP multi-tenant prefira Authorization ou X-API-Key; em stdio use ABACATE_PAY_API_KEY."
-        ),
+      apiKey: apiKeyParam("v1"),
       externalId: z.string().describe("Identificador externo do saque no seu sistema"),
     },
     async (params, extra) => {

--- a/tests/smoke/v2-read.smoke.ts
+++ b/tests/smoke/v2-read.smoke.ts
@@ -12,5 +12,6 @@ describe.skipIf(!ENABLED)("smoke v2 (read-only, chave real)", () => {
     const out = await tools.get("v2ListCustomers")!.handler({ apiKey: KEY, limit: 1 }, {});
     expect(out.content[0].text).not.toContain("HTTP 401");
     expect(out.content[0].text).not.toContain("API key é obrigatória");
+    expect(out.content[0].text).toMatch(/Nenhum cliente\.|^\d+\./);
   });
 });

--- a/tests/smoke/v2-read.smoke.ts
+++ b/tests/smoke/v2-read.smoke.ts
@@ -1,0 +1,16 @@
+import { describe, expect, test } from "bun:test";
+import { collectTools } from "../unit/helpers/harness.js";
+import { registerV2CustomerTools } from "../../src/tools/v2/customers.js";
+
+const ENABLED = process.env.ABACATE_PAY_SMOKE === "1";
+const KEY = process.env.ABACATE_PAY_API_KEY;
+
+describe.skipIf(!ENABLED)("smoke v2 (read-only, chave real)", () => {
+  test("v2ListCustomers responde sem erro de auth", async () => {
+    if (!KEY) throw new Error("Defina ABACATE_PAY_API_KEY (chave v2) para o smoke.");
+    const tools = collectTools(registerV2CustomerTools);
+    const out = await tools.get("v2ListCustomers")!.handler({ apiKey: KEY, limit: 1 }, {});
+    expect(out.content[0].text).not.toContain("HTTP 401");
+    expect(out.content[0].text).not.toContain("API key é obrigatória");
+  });
+});

--- a/tests/unit/api-key.test.ts
+++ b/tests/unit/api-key.test.ts
@@ -1,8 +1,13 @@
-import { describe, expect, test } from "bun:test";
+import { afterEach, describe, expect, test } from "bun:test";
 import { resolveApiKey } from "../../src/utils/api-key.js";
 import { setSessionApiKey, clearSessionApiKey } from "../../src/context.js";
 
+// Rode com `env -u ABACATE_PAY_API_KEY` — `src/config.ts` captura a chave global
+// no import; com a env setada o teste de placeholder não retornaria null.
+
 describe("resolveApiKey", () => {
+  afterEach(() => clearSessionApiKey("sess_1"));
+
   test("param não-placeholder tem prioridade", () => {
     expect(resolveApiKey(undefined, "abc_real_secret")).toBe("abc_real_secret");
   });
@@ -14,6 +19,5 @@ describe("resolveApiKey", () => {
   test("cai para a chave de sessão quando não há param válido", () => {
     setSessionApiKey("sess_1", "abc_session_secret");
     expect(resolveApiKey("sess_1", undefined)).toBe("abc_session_secret");
-    clearSessionApiKey("sess_1");
   });
 });

--- a/tests/unit/api-key.test.ts
+++ b/tests/unit/api-key.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, test } from "bun:test";
+import { resolveApiKey } from "../../src/utils/api-key.js";
+import { setSessionApiKey, clearSessionApiKey } from "../../src/context.js";
+
+describe("resolveApiKey", () => {
+  test("param não-placeholder tem prioridade", () => {
+    expect(resolveApiKey(undefined, "abc_real_secret")).toBe("abc_real_secret");
+  });
+
+  test("param placeholder é ignorado", () => {
+    expect(resolveApiKey(undefined, "api_key")).toBeNull();
+  });
+
+  test("cai para a chave de sessão quando não há param válido", () => {
+    setSessionApiKey("sess_1", "abc_session_secret");
+    expect(resolveApiKey("sess_1", undefined)).toBe("abc_session_secret");
+    clearSessionApiKey("sess_1");
+  });
+});

--- a/tests/unit/api.test.ts
+++ b/tests/unit/api.test.ts
@@ -1,0 +1,46 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { restoreFetch, stubFetch } from "./helpers/fetch-stub.js";
+import { makeAbacatePayRequest } from "../../src/http/api.js";
+
+const KEY = "abc_test_secret_123";
+afterEach(() => restoreFetch());
+
+describe("makeAbacatePayRequest", () => {
+  test("v1 → base /v1, v2 → base /v2", async () => {
+    let calls = stubFetch({ ok: true });
+    await makeAbacatePayRequest({ version: "v1", path: "/customer/list", apiKey: KEY, method: "GET" });
+    expect(calls[0].url).toBe("https://api.abacatepay.com/v1/customer/list");
+
+    calls = stubFetch({ ok: true });
+    await makeAbacatePayRequest({ version: "v2", path: "/customers/list", apiKey: KEY, method: "GET" });
+    expect(calls[0].url).toBe("https://api.abacatepay.com/v2/customers/list");
+  });
+
+  test("injeta Authorization Bearer", async () => {
+    const calls = stubFetch({ ok: true });
+    await makeAbacatePayRequest({ version: "v2", path: "/x", apiKey: KEY, method: "GET" });
+    const headers = calls[0].init.headers as Record<string, string>;
+    expect(headers.Authorization).toBe(`Bearer ${KEY}`);
+  });
+
+  test("erro HTTP vira Error com status e detalhe", async () => {
+    stubFetch({ error: "saldo insuficiente" }, 400);
+    await expect(
+      makeAbacatePayRequest({ version: "v2", path: "/x", apiKey: KEY, method: "GET" })
+    ).rejects.toThrow("saldo insuficiente");
+  });
+
+  test("version mismatch ganha dica", async () => {
+    stubFetch({ error: "version mismatch" }, 400);
+    await expect(
+      makeAbacatePayRequest({ version: "v1", path: "/x", apiKey: KEY, method: "GET" })
+    ).rejects.toThrow(/chaves da API v1/);
+  });
+
+  test("sem chave → erro de API key obrigatória", async () => {
+    stubFetch({ ok: true });
+    await expect(
+      makeAbacatePayRequest({ version: "v2", path: "/x", method: "GET" })
+    ).rejects.toThrow(/API key é obrigatória/);
+  });
+});

--- a/tests/unit/helpers/fetch-stub.ts
+++ b/tests/unit/helpers/fetch-stub.ts
@@ -1,0 +1,21 @@
+export type FetchCall = { url: string; init: RequestInit };
+
+let originalFetch: typeof globalThis.fetch | undefined;
+
+export function stubFetch(body: unknown, status = 200): FetchCall[] {
+  const calls: FetchCall[] = [];
+  if (originalFetch === undefined) originalFetch = globalThis.fetch;
+  globalThis.fetch = (async (url: unknown, init: RequestInit = {}) => {
+    calls.push({ url: String(url), init });
+    const text = typeof body === "string" ? body : JSON.stringify(body);
+    return new Response(text, {
+      status,
+      headers: { "Content-Type": "application/json" },
+    });
+  }) as typeof globalThis.fetch;
+  return calls;
+}
+
+export function restoreFetch(): void {
+  if (originalFetch) globalThis.fetch = originalFetch;
+}

--- a/tests/unit/helpers/fetch-stub.ts
+++ b/tests/unit/helpers/fetch-stub.ts
@@ -2,6 +2,7 @@ export type FetchCall = { url: string; init: RequestInit };
 
 let originalFetch: typeof globalThis.fetch | undefined;
 
+/** Substitui globalThis.fetch por um stub que responde body/status e registra as chamadas. */
 export function stubFetch(body: unknown, status = 200): FetchCall[] {
   const calls: FetchCall[] = [];
   if (originalFetch === undefined) originalFetch = globalThis.fetch;
@@ -17,5 +18,8 @@ export function stubFetch(body: unknown, status = 200): FetchCall[] {
 }
 
 export function restoreFetch(): void {
-  if (originalFetch) globalThis.fetch = originalFetch;
+  if (originalFetch) {
+    globalThis.fetch = originalFetch;
+    originalFetch = undefined;
+  }
 }

--- a/tests/unit/helpers/harness.ts
+++ b/tests/unit/helpers/harness.ts
@@ -1,6 +1,6 @@
 export type ToolHandler = (
   params: Record<string, unknown>,
-  extra: { sessionId?: string }
+  extra: { sessionId?: string; signal?: AbortSignal; authInfo?: unknown }
 ) => Promise<{ content: Array<{ type: "text"; text: string }> }>;
 
 export type CollectedTool = {
@@ -9,6 +9,7 @@ export type CollectedTool = {
   handler: ToolHandler;
 };
 
+/** Roda uma função registerXxxTools contra um McpServer falso e devolve um Map nome→tool. */
 export function collectTools(
   register: (server: { tool: (...args: any[]) => void }) => void
 ): Map<string, CollectedTool> {

--- a/tests/unit/helpers/harness.ts
+++ b/tests/unit/helpers/harness.ts
@@ -1,0 +1,23 @@
+export type ToolHandler = (
+  params: Record<string, unknown>,
+  extra: { sessionId?: string }
+) => Promise<{ content: Array<{ type: "text"; text: string }> }>;
+
+export type CollectedTool = {
+  description: string;
+  schema: Record<string, unknown>;
+  handler: ToolHandler;
+};
+
+export function collectTools(
+  register: (server: { tool: (...args: any[]) => void }) => void
+): Map<string, CollectedTool> {
+  const tools = new Map<string, CollectedTool>();
+  const fakeServer = {
+    tool(name: string, description: string, schema: Record<string, unknown>, handler: ToolHandler) {
+      tools.set(name, { description, schema, handler });
+    },
+  };
+  register(fakeServer);
+  return tools;
+}

--- a/tests/unit/shared.test.ts
+++ b/tests/unit/shared.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, test } from "bun:test";
+import { apiKeyParam, buildQuery, paginationHint, toolError } from "../../src/tools/shared.js";
+
+describe("buildQuery", () => {
+  test("omite undefined, null e string vazia", () => {
+    expect(buildQuery({ a: "x", b: undefined, c: null, d: "" })).toBe("?a=x");
+  });
+  test("string vazia quando nada resta", () => {
+    expect(buildQuery({ a: undefined })).toBe("");
+  });
+  test("encoda valores e aceita números", () => {
+    expect(buildQuery({ q: "a b", n: 10 })).toBe("?q=a+b&n=10");
+  });
+});
+
+describe("paginationHint", () => {
+  test("sem paginação → vazio", () => {
+    expect(paginationHint(undefined)).toBe("");
+  });
+  test("hasMore+next → dica de próxima página", () => {
+    expect(paginationHint({ hasMore: true, next: "cur_1" })).toContain('after="cur_1"');
+  });
+  test("before → dica de página anterior", () => {
+    expect(paginationHint({ before: "cur_0" })).toContain('before="cur_0"');
+  });
+});
+
+describe("toolError", () => {
+  test("Error → usa message", () => {
+    expect(toolError(new Error("boom")).content[0].text).toBe("boom");
+  });
+  test("não-Error → mensagem padrão", () => {
+    expect(toolError(42).content[0].text).toBe("Erro desconhecido");
+  });
+});
+
+describe("apiKeyParam", () => {
+  test("v1 tem descrição sem menção a v2", () => {
+    const d = (apiKeyParam("v1") as any)._def.description as string;
+    expect(d).toContain("ABACATE_PAY_API_KEY");
+    expect(d).not.toContain("v2");
+  });
+  test("v2 menciona chave v2", () => {
+    const d = (apiKeyParam("v2") as any)._def.description as string;
+    expect(d).toContain("v2");
+  });
+});

--- a/tests/unit/v1-fixation.test.ts
+++ b/tests/unit/v1-fixation.test.ts
@@ -1,0 +1,35 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { collectTools } from "./helpers/harness.js";
+import { restoreFetch, stubFetch } from "./helpers/fetch-stub.js";
+import { registerCustomerTools } from "../../src/tools/customer.js";
+
+const KEY = "abc_test_secret_123";
+
+afterEach(() => restoreFetch());
+
+describe("v1 createCustomer (fixação)", () => {
+  test("nome da tool e URL v1", async () => {
+    const tools = collectTools(registerCustomerTools);
+    expect(tools.has("createCustomer")).toBe(true);
+    expect(tools.has("listCustomers")).toBe(true);
+
+    const calls = stubFetch({ data: { id: "cust_1" } });
+    const out = await tools.get("createCustomer")!.handler(
+      { apiKey: KEY, name: "Ana", cellphone: "(11) 4002-8922", email: "a@b.com", taxId: "123" },
+      {}
+    );
+    expect(calls[0].url).toBe("https://api.abacatepay.com/v1/customer/create");
+    expect(out.content[0].text).toContain("Cliente criado com sucesso!");
+    expect(out.content[0].text).toContain("ID: cust_1");
+  });
+
+  test("erro mantém prefixo contextual da v1", async () => {
+    const tools = collectTools(registerCustomerTools);
+    stubFetch({ error: "boom" }, 400);
+    const out = await tools.get("createCustomer")!.handler(
+      { apiKey: KEY, name: "Ana", cellphone: "x", email: "a@b.com", taxId: "123" },
+      {}
+    );
+    expect(out.content[0].text).toContain("Falha ao criar cliente:");
+  });
+});

--- a/tests/unit/v1-fixation.test.ts
+++ b/tests/unit/v1-fixation.test.ts
@@ -13,6 +13,10 @@ describe("v1 createCustomer (fixação)", () => {
     expect(tools.has("createCustomer")).toBe(true);
     expect(tools.has("listCustomers")).toBe(true);
 
+    const schema = tools.get("createCustomer")!.schema;
+    expect((schema.apiKey as any)._def.description).not.toContain("v2");
+    expect((schema.apiKey as any)._def.typeName).toBe("ZodOptional");
+
     const calls = stubFetch({ data: { id: "cust_1" } });
     const out = await tools.get("createCustomer")!.handler(
       { apiKey: KEY, name: "Ana", cellphone: "(11) 4002-8922", email: "a@b.com", taxId: "123" },

--- a/tests/unit/v2-refunds.test.ts
+++ b/tests/unit/v2-refunds.test.ts
@@ -1,0 +1,53 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { collectTools } from "./helpers/harness.js";
+import { restoreFetch, stubFetch } from "./helpers/fetch-stub.js";
+import { registerV2CheckoutTools } from "../../src/tools/v2/checkouts.js";
+import { registerV2PaymentLinkTools } from "../../src/tools/v2/payment-links.js";
+import { registerV2TransparentTools } from "../../src/tools/v2/transparents.js";
+
+const KEY = "abc_test_secret_123";
+afterEach(() => restoreFetch());
+
+describe("v2RefundCheckout", () => {
+  test("POST /checkouts/refund com id+reason e refundPublicId na saída", async () => {
+    const tools = collectTools(registerV2CheckoutTools);
+    expect(tools.has("v2RefundCheckout")).toBe(true);
+    const calls = stubFetch({ data: { refundPublicId: "tran_refund789" } });
+    const out = await tools.get("v2RefundCheckout")!.handler(
+      { apiKey: KEY, id: "bill_abc", reason: "cancelado" },
+      {}
+    );
+    expect(calls[0].url).toBe("https://api.abacatepay.com/v2/checkouts/refund");
+    expect(calls[0].init.method).toBe("POST");
+    expect(JSON.parse(String(calls[0].init.body))).toEqual({ id: "bill_abc", reason: "cancelado" });
+    expect(out.content[0].text).toContain("tran_refund789");
+  });
+  test("omite reason quando ausente", async () => {
+    const tools = collectTools(registerV2CheckoutTools);
+    const calls = stubFetch({ data: { refundPublicId: "tran_x" } });
+    await tools.get("v2RefundCheckout")!.handler({ apiKey: KEY, id: "char_1" }, {});
+    expect(JSON.parse(String(calls[0].init.body))).toEqual({ id: "char_1" });
+  });
+});
+
+describe("v2RefundPaymentLink", () => {
+  test("POST /payment-links/refund", async () => {
+    const tools = collectTools(registerV2PaymentLinkTools);
+    expect(tools.has("v2RefundPaymentLink")).toBe(true);
+    const calls = stubFetch({ data: { refundPublicId: "tran_pl" } });
+    const out = await tools.get("v2RefundPaymentLink")!.handler({ apiKey: KEY, id: "bill_pl" }, {});
+    expect(calls[0].url).toBe("https://api.abacatepay.com/v2/payment-links/refund");
+    expect(out.content[0].text).toContain("tran_pl");
+  });
+});
+
+describe("v2RefundTransparentPix", () => {
+  test("POST /transparents/refund", async () => {
+    const tools = collectTools(registerV2TransparentTools);
+    expect(tools.has("v2RefundTransparentPix")).toBe(true);
+    const calls = stubFetch({ data: { refundPublicId: "tran_tp" } });
+    const out = await tools.get("v2RefundTransparentPix")!.handler({ apiKey: KEY, id: "pix_char_1" }, {});
+    expect(calls[0].url).toBe("https://api.abacatepay.com/v2/transparents/refund");
+    expect(out.content[0].text).toContain("tran_tp");
+  });
+});

--- a/tests/unit/v2-refunds.test.ts
+++ b/tests/unit/v2-refunds.test.ts
@@ -37,6 +37,8 @@ describe("v2RefundPaymentLink", () => {
     const calls = stubFetch({ data: { refundPublicId: "tran_pl" } });
     const out = await tools.get("v2RefundPaymentLink")!.handler({ apiKey: KEY, id: "bill_pl" }, {});
     expect(calls[0].url).toBe("https://api.abacatepay.com/v2/payment-links/refund");
+    expect(calls[0].init.method).toBe("POST");
+    expect(JSON.parse(String(calls[0].init.body))).toEqual({ id: "bill_pl" });
     expect(out.content[0].text).toContain("tran_pl");
   });
 });
@@ -48,6 +50,8 @@ describe("v2RefundTransparentPix", () => {
     const calls = stubFetch({ data: { refundPublicId: "tran_tp" } });
     const out = await tools.get("v2RefundTransparentPix")!.handler({ apiKey: KEY, id: "pix_char_1" }, {});
     expect(calls[0].url).toBe("https://api.abacatepay.com/v2/transparents/refund");
+    expect(calls[0].init.method).toBe("POST");
+    expect(JSON.parse(String(calls[0].init.body))).toEqual({ id: "pix_char_1" });
     expect(out.content[0].text).toContain("tran_tp");
   });
 });

--- a/tests/unit/v2-subscriptions.test.ts
+++ b/tests/unit/v2-subscriptions.test.ts
@@ -25,10 +25,11 @@ describe("v2ChangeSubscriptionPlan", () => {
     const tools = collectTools(registerV2SubscriptionTools);
     expect(tools.has("v2ChangeSubscriptionPlan")).toBe(true);
     const calls = stubFetch({ data: { id: "subs_1", productId: "prod_pro" } });
-    await tools.get("v2ChangeSubscriptionPlan")!.handler(
+    const out = await tools.get("v2ChangeSubscriptionPlan")!.handler(
       { apiKey: KEY, id: "subs_1", productId: "prod_pro", quantity: 2 },
       {}
     );
+    expect(out.content[0].text).toContain("prod_pro");
     expect(calls[0].url).toBe("https://api.abacatepay.com/v2/subscriptions/change-plan");
     expect(calls[0].init.method).toBe("POST");
     expect(JSON.parse(String(calls[0].init.body))).toEqual({ id: "subs_1", productId: "prod_pro", quantity: 2 });
@@ -40,7 +41,7 @@ describe("v2RecordSubscriptionUsage", () => {
     const tools = collectTools(registerV2SubscriptionTools);
     expect(tools.has("v2RecordSubscriptionUsage")).toBe(true);
     const calls = stubFetch({ data: { id: "usage_1" } });
-    await tools.get("v2RecordSubscriptionUsage")!.handler(
+    const out = await tools.get("v2RecordSubscriptionUsage")!.handler(
       { apiKey: KEY, id: "subs_1", productId: "prod_api", units: 50, action: "add" },
       {}
     );
@@ -52,5 +53,16 @@ describe("v2RecordSubscriptionUsage", () => {
       units: 50,
       action: "add",
     });
+    expect(out.content[0].text).toContain("usage_1");
+  });
+
+  test("action subtract é passado no body", async () => {
+    const tools = collectTools(registerV2SubscriptionTools);
+    const calls = stubFetch({ data: { id: "usage_2" } });
+    await tools.get("v2RecordSubscriptionUsage")!.handler(
+      { apiKey: KEY, id: "subs_1", productId: "prod_api", units: 5, action: "subtract" },
+      {}
+    );
+    expect(JSON.parse(String(calls[0].init.body))).toMatchObject({ action: "subtract" });
   });
 });

--- a/tests/unit/v2-subscriptions.test.ts
+++ b/tests/unit/v2-subscriptions.test.ts
@@ -1,0 +1,56 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { collectTools } from "./helpers/harness.js";
+import { restoreFetch, stubFetch } from "./helpers/fetch-stub.js";
+import { registerV2SubscriptionTools } from "../../src/tools/v2/subscriptions.js";
+
+const KEY = "abc_test_secret_123";
+afterEach(() => restoreFetch());
+
+describe("v2CancelSubscription", () => {
+  test("POST /subscriptions/cancel com id", async () => {
+    const tools = collectTools(registerV2SubscriptionTools);
+    expect(tools.has("v2CancelSubscription")).toBe(true);
+    const calls = stubFetch({ data: { id: "subs_1", status: "CANCELLED" } });
+    const out = await tools.get("v2CancelSubscription")!.handler({ apiKey: KEY, id: "subs_1" }, {});
+    expect(calls[0].url).toBe("https://api.abacatepay.com/v2/subscriptions/cancel");
+    expect(calls[0].init.method).toBe("POST");
+    expect(JSON.parse(String(calls[0].init.body))).toEqual({ id: "subs_1" });
+    expect(out.content[0].text).toContain("subs_1");
+    expect(out.content[0].text).toContain("CANCELLED");
+  });
+});
+
+describe("v2ChangeSubscriptionPlan", () => {
+  test("POST /subscriptions/change-plan com id+productId+quantity", async () => {
+    const tools = collectTools(registerV2SubscriptionTools);
+    expect(tools.has("v2ChangeSubscriptionPlan")).toBe(true);
+    const calls = stubFetch({ data: { id: "subs_1", productId: "prod_pro" } });
+    await tools.get("v2ChangeSubscriptionPlan")!.handler(
+      { apiKey: KEY, id: "subs_1", productId: "prod_pro", quantity: 2 },
+      {}
+    );
+    expect(calls[0].url).toBe("https://api.abacatepay.com/v2/subscriptions/change-plan");
+    expect(calls[0].init.method).toBe("POST");
+    expect(JSON.parse(String(calls[0].init.body))).toEqual({ id: "subs_1", productId: "prod_pro", quantity: 2 });
+  });
+});
+
+describe("v2RecordSubscriptionUsage", () => {
+  test("POST /subscriptions/record-usage com action add", async () => {
+    const tools = collectTools(registerV2SubscriptionTools);
+    expect(tools.has("v2RecordSubscriptionUsage")).toBe(true);
+    const calls = stubFetch({ data: { id: "usage_1" } });
+    await tools.get("v2RecordSubscriptionUsage")!.handler(
+      { apiKey: KEY, id: "subs_1", productId: "prod_api", units: 50, action: "add" },
+      {}
+    );
+    expect(calls[0].url).toBe("https://api.abacatepay.com/v2/subscriptions/record-usage");
+    expect(calls[0].init.method).toBe("POST");
+    expect(JSON.parse(String(calls[0].init.body))).toEqual({
+      id: "subs_1",
+      productId: "prod_api",
+      units: 50,
+      action: "add",
+    });
+  });
+});

--- a/tests/unit/v2-webhooks.test.ts
+++ b/tests/unit/v2-webhooks.test.ts
@@ -52,8 +52,10 @@ describe("v2GetWebhook", () => {
   test("GET /webhooks/get?id=", async () => {
     const tools = collectTools(registerV2WebhookTools);
     const calls = stubFetch({ data: { id: "webh_1" } });
-    await tools.get("v2GetWebhook")!.handler({ apiKey: KEY, id: "webh_1" }, {});
+    const out = await tools.get("v2GetWebhook")!.handler({ apiKey: KEY, id: "webh_1" }, {});
     expect(calls[0].url).toBe("https://api.abacatepay.com/v2/webhooks/get?id=webh_1");
+    expect(calls[0].init.method).toBe("GET");
+    expect(out.content[0].text).toContain("webh_1");
   });
 });
 

--- a/tests/unit/v2-webhooks.test.ts
+++ b/tests/unit/v2-webhooks.test.ts
@@ -1,0 +1,70 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { collectTools } from "./helpers/harness.js";
+import { restoreFetch, stubFetch } from "./helpers/fetch-stub.js";
+import { registerV2WebhookTools } from "../../src/tools/v2/webhooks.js";
+
+const KEY = "abc_test_secret_123";
+afterEach(() => restoreFetch());
+
+describe("v2CreateWebhook", () => {
+  test("POST /webhooks/create com payload completo", async () => {
+    const tools = collectTools(registerV2WebhookTools);
+    expect(tools.has("v2CreateWebhook")).toBe(true);
+    const calls = stubFetch({ data: { id: "webh_1", name: "Pagamentos", endpoint: "https://x.com/wh" } });
+    const out = await tools.get("v2CreateWebhook")!.handler(
+      {
+        apiKey: KEY,
+        name: "Pagamentos",
+        endpoint: "https://x.com/wh",
+        secret: "s3cr3t",
+        events: ["checkout.completed", "subscription.renewed"],
+      },
+      {}
+    );
+    expect(calls[0].url).toBe("https://api.abacatepay.com/v2/webhooks/create");
+    expect(calls[0].init.method).toBe("POST");
+    expect(JSON.parse(String(calls[0].init.body))).toEqual({
+      name: "Pagamentos",
+      endpoint: "https://x.com/wh",
+      secret: "s3cr3t",
+      events: ["checkout.completed", "subscription.renewed"],
+    });
+    expect(out.content[0].text).toContain("webh_1");
+  });
+});
+
+describe("v2ListWebhooks", () => {
+  test("GET /webhooks/list com query e paginação", async () => {
+    const tools = collectTools(registerV2WebhookTools);
+    const calls = stubFetch({
+      data: [{ id: "webh_1", name: "Pag", endpoint: "https://x.com/wh" }],
+      pagination: { hasMore: true, next: "cur_2" },
+    });
+    const out = await tools.get("v2ListWebhooks")!.handler({ apiKey: KEY, limit: 10, search: "pag" }, {});
+    expect(calls[0].url).toBe("https://api.abacatepay.com/v2/webhooks/list?limit=10&search=pag");
+    expect(calls[0].init.method).toBe("GET");
+    expect(out.content[0].text).toContain("webh_1");
+    expect(out.content[0].text).toContain('after="cur_2"');
+  });
+});
+
+describe("v2GetWebhook", () => {
+  test("GET /webhooks/get?id=", async () => {
+    const tools = collectTools(registerV2WebhookTools);
+    const calls = stubFetch({ data: { id: "webh_1" } });
+    await tools.get("v2GetWebhook")!.handler({ apiKey: KEY, id: "webh_1" }, {});
+    expect(calls[0].url).toBe("https://api.abacatepay.com/v2/webhooks/get?id=webh_1");
+  });
+});
+
+describe("v2DeleteWebhook", () => {
+  test("POST /webhooks/delete com id", async () => {
+    const tools = collectTools(registerV2WebhookTools);
+    const calls = stubFetch({ data: { id: "webh_1" } });
+    const out = await tools.get("v2DeleteWebhook")!.handler({ apiKey: KEY, id: "webh_1" }, {});
+    expect(calls[0].url).toBe("https://api.abacatepay.com/v2/webhooks/delete");
+    expect(calls[0].init.method).toBe("POST");
+    expect(JSON.parse(String(calls[0].init.body))).toEqual({ id: "webh_1" });
+    expect(out.content[0].text).toContain("webh_1");
+  });
+});


### PR DESCRIPTION
## Summary
- Adiciona as 10 tools v2 que faltavam: refunds (checkout/payment-link/transparent), ciclo de assinatura (cancel/change-plan/record-usage) e webhooks (create/list/get/delete).
- Extrai helpers de tool para `src/tools/shared.ts`; tools v1 passam a usar `apiKeyParam` compartilhado (refactor sem mudança de comportamento).
- Adiciona suíte `bun:test`: unit com `fetch` mockado (roda no CI) + smoke gated por `ABACATE_PAY_SMOKE`.
- Adiciona step de testes no CI e corrige 9 erros de lint pré-existentes (globals URL/AbortSignal + paths fs do OAuth justificados com disable), que deixavam o CI vermelho antes mesmo dos testes.

## Test plan
- [x] `bun test tests/unit` → 32 pass
- [x] `bunx tsc --noEmit` limpo
- [x] `bun run lint` → 0 errors
- [ ] smoke (opcional): `ABACATE_PAY_API_KEY=<chave v2> bun run test:smoke`